### PR TITLE
Fix undeclared class

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,43 @@
+# Building instructions for Linux Fedora 25
+
+Note: this was tested in a docker container
+
+1. Install build dependencies
+
+```bash
+sudo dnf install -y gcc gcc-c++
+```
+
+Some libraries in Fedora 25 are too old, so we must fetch them from Fedora rawhide:
+
+```bash
+sudo dnf install -y fedora-repos-rawhide
+sudo dnf install -y --enablerepo rawhide boost boost-devel cmake
+```
+
+2. Create a build directory
+
+Do this inside of the repo root
+
+```bash
+mkdir builddir
+cd builddir
+```
+
+3. Create the `Makefile` using `cmake`
+
+```bash
+cmake ..
+```
+
+4. Start the building using `make`
+
+```bash
+make
+```
+
+5. Run the built executable
+
+```bash
+./pygen
+```

--- a/function.h
+++ b/function.h
@@ -3,6 +3,8 @@
 #ifndef FUNCTION_H
 #define FUNCTION_H
 
+class DataType;
+
 struct Function {
 
     public:


### PR DESCRIPTION
This merge request 
1. fixes a problem with building `function.h`
2. adds build instructions for Fedora 25

This is the problem which I encountered:
```
$ make
In file included from /PythonGenerator/variable.h:4:0,
                 from /PythonGenerator/main.cpp:5:
/PythonGenerator/function.h:11:15: error: 'DataType' does not name a type
         const DataType* return_type;
               ^~~~~~~~
```

Why: I was searching for "python random program generator" in github, found this repo and was wondering what this program does :)